### PR TITLE
Feature: Disable on 404 page

### DIFF
--- a/SlickEngagement_Plugin.php
+++ b/SlickEngagement_Plugin.php
@@ -654,6 +654,11 @@ JSBLOCK;
     //TODO: Clean this up / migrate to SR functions
     public function addSlickPageHeader()
     {
+        // @TODO: Confirm that this doesn't cause issues with Slickstream itself.
+        if (is_404()) {
+            return;
+        }
+
         global $post;
         echo "\n";
         $this->echoSlickstreamComment("Page Generated at: " . $this->getCurrentTimeStampByTimeZone('UTC') . " UTC");

--- a/SlickEngagement_Plugin.php
+++ b/SlickEngagement_Plugin.php
@@ -318,7 +318,7 @@ class SlickEngagement_Plugin extends SlickEngagement_LifeCycle
         $headers = array('referer' => home_url());
         $this->echoSlickstreamComment("Fetch endpoint: " . $remote);
         $this->echoSlickstreamComment("Headers: " . json_encode($headers));
-        $response = wp_remote_get($remote , array('timeout' => 2, 'headers' => $headers));
+        $response = wp_remote_get($remote, array('timeout' => 2, 'headers' => $headers));
         $response_code = wp_remote_retrieve_response_code( $response );
         $response_text = wp_remote_retrieve_body($response);
 
@@ -545,12 +545,14 @@ class SlickEngagement_Plugin extends SlickEngagement_LifeCycle
             return;
         }
 
-        if ( ( $force_fetch_boot_data || $no_transient_data || $is_expired || $slick_boot_param_not_set ) ) {
+        if ( ( $force_fetch_boot_data || $no_transient_data || $is_expired ) ) {
             if ( ! wp_next_scheduled( 'slickstream_fetch_boot_data', [ $siteCode, $transient_name, $transient_name_ttl ] ) ) {
                 $this->echoSlickstreamComment("Requesting page boot data via cron.");
                 wp_schedule_single_event( time(), 'slickstream_fetch_boot_data', [ $siteCode, $transient_name, $transient_name_ttl ] );
                 return;
             }
+
+            return;
         } else {
             $this->echoSlickstreamComment("Using cached page boot data: " . $transient_name);
         }
@@ -936,7 +938,7 @@ JSBLOCK;
             return;
         }
 
-        $boot_data_obj = $this->fetchBootData($siteCode);  // Most time consuming. So bypassed with stale while revalidate.
+        $boot_data_obj = $this->fetchBootData( $siteCode );  // Most time consuming. So bypassed with stale while revalidate.
         if ( ! $boot_data_obj ) {
             // If the boot data is not fetched, reset the ttl to 15 minutes to retry fetching the boot data.
             set_transient( $transient_name_ttl, time() + ( 15 * MINUTE_IN_SECONDS ), 0);
@@ -944,6 +946,6 @@ JSBLOCK;
         }
 
         set_transient( $transient_name, $boot_data_obj, 0 ); // Set with no expiration, the cache will be invalidated by the TTL through cron.
-        set_transient( $transient_name_ttl, time() + ( 15 * MINUTE_IN_SECONDS) , 0 );
+        set_transient( $transient_name_ttl, time() + ( 15 * MINUTE_IN_SECONDS), 0 );
     }
 }

--- a/SlickEngagement_Plugin.php
+++ b/SlickEngagement_Plugin.php
@@ -531,7 +531,7 @@ class SlickEngagement_Plugin extends SlickEngagement_LifeCycle
         $this->handleDeleteBootData();
 
         $no_transient_data = false === ($boot_data_obj = get_transient($transient_name)); //get_transient returns `false` if the key doesn't exist
-        $is_expired = get_transient($transient_name_ttl) < time();
+        $is_expired = get_transient( $transient_name_ttl ) < time();
 
         // If `slick-boot=1` is passed as a query param, force a re-fetch of the boot data from the server
         // If `slick-boot=0` is passed as a query param, skip fetching boot data from the server
@@ -540,14 +540,14 @@ class SlickEngagement_Plugin extends SlickEngagement_LifeCycle
         $dont_load_boot_data = ($slick_boot_param === '0');
         $slick_boot_param_not_set = ($slick_boot_param === null);
 
-        if ($dont_load_boot_data) {
+        if ( $dont_load_boot_data ) {
             $this->echoSlickstreamComment("Skipping page boot data and CLS output");
             return;
         }
 
         if ( ( $force_fetch_boot_data || $no_transient_data || $is_expired ) ) {
             if ( ! wp_next_scheduled( 'slickstream_fetch_boot_data', [ $siteCode, $transient_name, $transient_name_ttl ] ) ) {
-                $this->echoSlickstreamComment("Requesting page boot data via cron.");
+                $this->echoSlickstreamComment( 'Requesting page boot data via cron.' );
                 wp_schedule_single_event( time(), 'slickstream_fetch_boot_data', [ $siteCode, $transient_name, $transient_name_ttl ] );
             }
         } else {
@@ -943,6 +943,6 @@ JSBLOCK;
         }
 
         set_transient( $transient_name, $boot_data_obj, 0 ); // Set with no expiration, the cache will be invalidated by the TTL through cron.
-        set_transient( $transient_name_ttl, time() + ( 15 * MINUTE_IN_SECONDS), 0 );
+        set_transient( $transient_name_ttl, time() + ( 15 * MINUTE_IN_SECONDS ), 0 );
     }
 }

--- a/SlickEngagement_Plugin.php
+++ b/SlickEngagement_Plugin.php
@@ -104,7 +104,7 @@ class SlickEngagement_Plugin extends SlickEngagement_LifeCycle
         add_action('init', array(&$this, 'add_taxonomies_to_pages'));
 
         // Register cron hook for processing.
-        add_filter( 'slickstream_fetch_boot_data', array( &$this, 'process_fetch_boot_data' ), 10, 3 );
+        add_action( 'slickstream_fetch_boot_data', array( &$this, 'process_fetch_boot_data' ), 10, 3 );
 
         $prefix = is_network_admin() ? 'network_admin_' : '';
         $plugin_file = plugin_basename($this->getPluginDir() . DIRECTORY_SEPARATOR . $this->getMainPluginFileName()); //plugin_basename( $this->getMainPluginFileName() );
@@ -525,7 +525,7 @@ class SlickEngagement_Plugin extends SlickEngagement_LifeCycle
         global $wp;
 
         $transient_name = $this->getTransientName(); // Name for WP Transient Cache API Key
-        $transient_name_ttl = $this->getTransientName() . '_ttl'; // Name for WP Transient Cache TTL Key
+        $transient_name_ttl = $transient_name . '_ttl'; // Name for WP Transient Cache TTL Key
 
         // If `delete-boot=1` is passed as a query param, delete the stored page boot data
         $this->handleDeleteBootData();

--- a/SlickEngagement_Plugin.php
+++ b/SlickEngagement_Plugin.php
@@ -325,7 +325,7 @@ class SlickEngagement_Plugin extends SlickEngagement_LifeCycle
         if ($response_code === 200) {
             return json_decode($response_text);
         } else {
-            $this->echoSlickstreamComment("Error fetching boot data: " . $response_text);
+            error_log( "Error fetching boot data: " . print_r( $response_text, true ) );
             return null;
         }
     }

--- a/SlickEngagement_Plugin.php
+++ b/SlickEngagement_Plugin.php
@@ -321,9 +321,10 @@ class SlickEngagement_Plugin extends SlickEngagement_LifeCycle
         $response_text = wp_remote_retrieve_body($response);
 
         if ($response_code === 200) {
+            $this->echoSlickstreamComment( "Fetch successful." );
             return json_decode($response_text);
         } else {
-            error_log( "Error fetching boot data: " . print_r( $response_text, true ) );
+            $this->echoSlickstreamComment( "Error fetching boot data: " . $response_text );
             return null;
         }
     }
@@ -332,7 +333,7 @@ class SlickEngagement_Plugin extends SlickEngagement_LifeCycle
         $boot_data_json = json_encode($boot_data_obj);
 
         if (false === $boot_data_json) {
-            $this->echoSlickstreamComment('Error encoding page boot data JSON');
+            $this->echoSlickstreamComment('Error encoding page boot data JSON', true);
             return;
         }
 
@@ -414,7 +415,7 @@ class SlickEngagement_Plugin extends SlickEngagement_LifeCycle
     //Returns a name for the "page boot data" transient
     private function getTransientName( $page_url )
     {
-        defined('PAGE_BOOT_DATA_TRANSIENT_PREFIX') || define('PAGE_BOOT_DATA_TRANSIENT_PREFIX', 'slick_page_boot_');
+        defined( 'PAGE_BOOT_DATA_TRANSIENT_PREFIX' ) || define( 'PAGE_BOOT_DATA_TRANSIENT_PREFIX', 'slick_page_boot_' );
         // Use get_the_permalink() instead of $_SERVER['REQUEST_URI'] to avoid issues with:
         // query strings, hashed URLs, comment pagination etc. Creates less overhead due to being
         // called only on the "parent" page instead of every variation of the page.
@@ -428,7 +429,7 @@ class SlickEngagement_Plugin extends SlickEngagement_LifeCycle
         return $debugModeParam === "1";
     }
 
-    private function echoSlickstreamComment($comment, $echoToConsole = true)
+    private function echoSlickstreamComment($comment, $echoToConsole = false)
     {
         echo "<!-- [slickstream] " . $comment . " -->\n";
 

--- a/SlickEngagement_Plugin.php
+++ b/SlickEngagement_Plugin.php
@@ -549,10 +549,7 @@ class SlickEngagement_Plugin extends SlickEngagement_LifeCycle
             if ( ! wp_next_scheduled( 'slickstream_fetch_boot_data', [ $siteCode, $transient_name, $transient_name_ttl ] ) ) {
                 $this->echoSlickstreamComment("Requesting page boot data via cron.");
                 wp_schedule_single_event( time(), 'slickstream_fetch_boot_data', [ $siteCode, $transient_name, $transient_name_ttl ] );
-                return;
             }
-
-            return;
         } else {
             $this->echoSlickstreamComment("Using cached page boot data: " . $transient_name);
         }

--- a/SlickEngagement_Plugin.php
+++ b/SlickEngagement_Plugin.php
@@ -520,6 +520,16 @@ class SlickEngagement_Plugin extends SlickEngagement_LifeCycle
             return;
         }
 
+        $page_id = get_the_ID();
+        $page = get_post( $page_id );
+        if ( ! $page ) {
+            return;
+        }
+
+        if ( in_array( $page->post_type, apply_filters( 'slickstream_exclude_post_types', [] ), true ) ) {
+            return;
+        }
+
         $page_url = get_the_permalink();
         if ( ! $page_url ) {
             return;

--- a/composer.lock
+++ b/composer.lock
@@ -1,0 +1,18 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+        "This file is @generated automatically"
+    ],
+    "content-hash": "ecb3e0de94967436a750764bb0fee657",
+    "packages": [],
+    "packages-dev": [],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": [],
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": [],
+    "platform-dev": [],
+    "plugin-api-version": "2.6.0"
+}


### PR DESCRIPTION
Currently Slickstream runs on 404 page, since this can be an unlimited number of URLs it becomes a performance issue for servers that contain lots of 404s.

Lets disable on 404 pages.